### PR TITLE
Update weboslayers.py

### DIFF
--- a/weboslayers.py
+++ b/weboslayers.py
@@ -59,9 +59,9 @@ Machines = ['qemux86', 'qemuarm']
 # repositories on git.openembedded.org
 webos_layers = [
 ('bitbake',               -1, 'git://github.com/openembedded/bitbake.git',              'branch=1.18,commit=0f7b6a0', ''),
-('meta',                   5, 'git://github.com/openembedded/oe-core.git',              'branch=dylan,commit=bf2d538', ''),
-('meta-oe',                6, 'git://github.com/openembedded/meta-oe.git',              'branch=dylan,commit=70ebe86', ''),
-('meta-networking',        6, 'git://github.com/openembedded/meta-oe.git',              '', ''),
+('meta',                   5, 'git://github.com/openembedded/openembedded-core.git',              'branch=dylan,commit=bf2d538', ''),
+('meta-oe',                6, 'git://github.com/openembedded/meta-openembedded.git',              'branch=dylan,commit=70ebe86', ''),
+('meta-networking',        6, 'git://github.com/openembedded/meta-openembedded.git',              '', ''),
 
 ('meta-webos-backports',   9, 'git://github.com/openwebos/meta-webos-backports.git',    'commit=ed80399', ''),
 ('meta-webos',            10, 'git://github.com/openwebos/meta-webos.git',              'commit=f43220d', ''),


### PR DESCRIPTION
There are no more /openembedded/oe-core and /openembedded/meta-oe, now used /openembedded/openembedded-core and /openembedded/meta-openembedded

Lines
62 ('meta',                         5, 'git://github.com/openembedded/oe-core.git',              'branch=dylan,commit=bf2d538', ''),
63 ('meta-oe',                    6, 'git://github.com/openembedded/meta-oe.git',              'branch=dylan,commit=70ebe86', ''),
64 ('meta-networking',        6, 'git://github.com/openembedded/meta-oe.git',              '', ''),

were changed to

62 ('meta',                         5, 'git://github.com/openembedded/openembedded-core.git',              'branch=dylan,commit=bf2d538', ''),
63 ('meta-oe',                    6, 'git://github.com/openembedded/meta-openembedded.git',              'branch=dylan,commit=70ebe86', ''),
64 ('meta-networking',        6, 'git://github.com/openembedded/meta-openembedded.git',              '', ''),
